### PR TITLE
Add AKS ingress to helm charts

### DIFF
--- a/src/frontend/src/chart/templates/aks-ingress.yaml
+++ b/src/frontend/src/chart/templates/aks-ingress.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.aksIngress.baseDomain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "frontend.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+spec:
+  rules:
+  - host: {{ template "frontend.fullname" . }}.{{ .Values.aksIngress.baseDomain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "frontend.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+        path: /
+{{- end }}

--- a/src/frontend/src/chart/values.yaml
+++ b/src/frontend/src/chart/values.yaml
@@ -54,3 +54,8 @@ tolerations: []
 affinity: {}
 
 displaySqlInfo: ""
+customTitle: "TAILWIND TRADERS"
+
+aksIngress:
+  baseDomain: ''
+  

--- a/src/inventory-service/InventoryService.Api/chart/templates/aks-ingress.yaml
+++ b/src/inventory-service/InventoryService.Api/chart/templates/aks-ingress.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.aksIngress.baseDomain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "inventoryservice.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+spec:
+  rules:
+  - host: {{ template "inventoryservice.fullname" . }}.{{ .Values.aksIngress.baseDomain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "inventoryservice.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+        path: /
+{{- end }}

--- a/src/inventory-service/InventoryService.Api/chart/values.yaml
+++ b/src/inventory-service/InventoryService.Api/chart/values.yaml
@@ -50,3 +50,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+aksIngress:
+  baseDomain: ''
+  

--- a/src/product-service/src/chart/templates/aks-ingress.yaml
+++ b/src/product-service/src/chart/templates/aks-ingress.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.aksIngress.baseDomain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "productservice.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+spec:
+  rules:
+  - host: {{ template "productservice.fullname" . }}.{{ .Values.aksIngress.baseDomain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "productservice.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+        path: /
+{{- end }}

--- a/src/product-service/src/chart/values.yaml
+++ b/src/product-service/src/chart/values.yaml
@@ -48,3 +48,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+aksIngress:
+  baseDomain: ''
+  


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add AKS ingress to helm charts. If a baseDomain is supplied, it will deploy an ingress resource for the HTTP application routing addon

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

